### PR TITLE
Add accessor to internal event_base

### DIFF
--- a/src/eventdispatcher_libevent.cpp
+++ b/src/eventdispatcher_libevent.cpp
@@ -66,6 +66,16 @@ EventDispatcherLibEvent::~EventDispatcherLibEvent(void)
 }
 
 /**
+ * Retrieve the libevent event_base for this dispatcher
+ * @return The event_base for this dispatcher
+ */
+struct event_base* EventDispatcherLibEvent::eventBase() const
+{
+	const Q_D(EventDispatcherLibEvent);
+	return d->eventBase();
+}
+
+/**
  * @brief Processes pending events that match @a flags until there are no more events to process
  * @param flags
  * @return Whether an event has been processed

--- a/src/eventdispatcher_libevent.h
+++ b/src/eventdispatcher_libevent.h
@@ -3,6 +3,8 @@
 
 #include <QtCore/QAbstractEventDispatcher>
 
+struct event_base;
+
 class EventDispatcherLibEventPrivate;
 class EventDispatcherLibEventConfig;
 
@@ -12,6 +14,8 @@ public:
 	explicit EventDispatcherLibEvent(QObject* parent = 0);
 	EventDispatcherLibEvent(const EventDispatcherLibEventConfig& config, QObject* parent = 0);
 	virtual ~EventDispatcherLibEvent(void);
+
+	struct event_base* eventBase() const;
 
 	virtual bool processEvents(QEventLoop::ProcessEventsFlags flags);
 	virtual bool hasPendingEvents(void);

--- a/src/eventdispatcher_libevent_p.cpp
+++ b/src/eventdispatcher_libevent_p.cpp
@@ -231,6 +231,16 @@ bool EventDispatcherLibEventPrivate::processEvents(QEventLoop::ProcessEventsFlag
 
 /**
  * @internal
+ * @brief event_base accessor
+ * @return The internal event_base for this dispatcher
+ */
+struct event_base* EventDispatcherLibEventPrivate::eventBase() const
+{
+	return m_base;
+}
+
+/**
+ * @internal
  * @brief Wakeup handler
  * @param fd Not used
  * @param events Not used

--- a/src/eventdispatcher_libevent_p.h
+++ b/src/eventdispatcher_libevent_p.h
@@ -40,6 +40,8 @@ public:
 	QList<QAbstractEventDispatcher::TimerInfo> registeredTimers(QObject* object) const;
 	int remainingTime(int timerId) const;
 
+	struct event_base* eventBase() const;
+
 	typedef QMultiHash<evutil_socket_t, SocketNotifierInfo> SocketNotifierHash;
 	typedef QHash<int, TimerInfo*> TimerHash;
 	typedef QPair<QPointer<QObject>, QEvent*> PendingEvent;


### PR DESCRIPTION
Most libevent APIs require an event_base to register timers and fd notifiers.
Integrating a evhttp server with the Qt event-loop requires access to the
event_base for the current thread which is hidden in the internal private class.
This patch makes the event_base accessible to applications that require this
type of integration.
